### PR TITLE
Bugfix/7/hang with concurrent tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,8 +85,15 @@ ENV ENVIRONMENT=$env
 # Postgres Database URL. Required.
 # ENV API_TEST_DATABASE_URL
 
+# Redis URL. Required.
+# ENV API_TEST_REDIS_URL
+
+# Jobs Queue runs in process. Optional. If false (or undefined),
+#   a jobs process must be run separately.
+# ENV API_TEST_IN_PROCESS_QUEUES
+
 ##
-## Serve (default command)
+## serve (default command)
 ##
 
 # --env
@@ -97,3 +104,11 @@ ENV ENVIRONMENT=$env
 
 ENTRYPOINT ["./Run"]
 CMD ["serve", "--env", "$ENVIRONMENT", "--hostname", "0.0.0.0", "--port", "80"]
+
+##
+## queues
+##
+
+# Use this command to run the queues service outside of the API server process.
+# This is the recommended way to run the Jobs Queue.
+# CMD ["queues"]

--- a/Package.resolved
+++ b/Package.resolved
@@ -137,6 +137,42 @@
         }
       },
       {
+        "package": "queues",
+        "repositoryURL": "https://github.com/vapor/queues.git",
+        "state": {
+          "branch": null,
+          "revision": "f0c35103654695a8938cd3e406044d252951e89c",
+          "version": "1.2.0"
+        }
+      },
+      {
+        "package": "queues-redis-driver",
+        "repositoryURL": "https://github.com/vapor/queues-redis-driver",
+        "state": {
+          "branch": "master",
+          "revision": "2212b5daf46a35de6da1ea91af2e0cc927247ccb",
+          "version": null
+        }
+      },
+      {
+        "package": "redis-kit",
+        "repositoryURL": "https://github.com/vapor/redis-kit.git",
+        "state": {
+          "branch": null,
+          "revision": "9ef8f9dc472d022c4e94e5388ccf3c87ad83e2cb",
+          "version": "1.0.0-beta.5"
+        }
+      },
+      {
+        "package": "RediStack",
+        "repositoryURL": "https://gitlab.com/mordil/RediStack.git",
+        "state": {
+          "branch": null,
+          "revision": "8b75ef7f0e3cb82c69f2e2b47ea8f49e7d4e2ca9",
+          "version": "1.0.0-alpha.10"
+        }
+      },
+      {
         "package": "RichJSONParser",
         "repositoryURL": "https://github.com/omochi/RichJSONParser.git",
         "state": {
@@ -278,15 +314,6 @@
           "branch": null,
           "revision": "0688b9cfc4c3dd234e4f55f1f056b2affc849873",
           "version": "0.50200.0"
-        }
-      },
-      {
-        "package": "vapor",
-        "repositoryURL": "https://github.com/vapor/vapor",
-        "state": {
-          "branch": null,
-          "revision": "dc2aa1e02e04a47b67cb0dabed628fe844900f30",
-          "version": "4.14.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/fluent-postgres-driver", from: "2.0.0-rc.2"),
         .package(url: "https://github.com/vapor/fluent", from: "4.0.0-rc.2.2"),
         .package(url: "https://github.com/vapor/fluent-kit", from: "1.0.0-rc.1.26"),
+        .package(url: "https://github.com/vapor/queues-redis-driver", .branch("master")),
 
         .package(url: "https://github.com/mattpolzin/VaporTypedRoutes", .upToNextMinor(from: "0.7.0")),
         .package(url: "https://github.com/mattpolzin/VaporOpenAPI", .upToNextMinor(from: "0.0.13")),
@@ -39,6 +40,7 @@ let package = Package(
           .product(name: "Vapor", package: "vapor"), 
           .product(name: "Fluent", package: "fluent"),
           .product(name: "FluentPostgresDriver", package: "fluent-postgres-driver"), 
+          .product(name: "QueuesRedisDriver", package: "queues-redis-driver"),
           .product(name: "VaporTypedRoutes", package: "VaporTypedRoutes"),
           .product(name: "VaporOpenAPI", package: "VaporOpenAPI"),
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # JSON:API/OpenAPI Test Server
 ## Requirements
 ### Server
-The test server requires a Postgres database.
+The test server requires a Postgres database and Redis instace.
 
 ## Usage
 
@@ -73,16 +73,16 @@ docker run --rm --env 'API_TEST_IN_URL=https://website.com/api/documentation' -v
 You will find the dumped files at `./out/api_test_files.zip`.
 
 ### The Test Server
-You can run an API Test server that accepts requests to run tests at HTTP endpoints. This requires the same input file or URL environment variables explained in the above section but you also must provide a Postgres database for the server to use as its persistence layer. You specify this database using a Postgres URL in the `API_TEST_DATABASE_URL` environment variable.
+You can run an API Test server that accepts requests to run tests at HTTP endpoints. This requires the same input file or URL environment variables explained in the above section but you also must provide a Postgres database for the server to use as its persistence layer. You specify this database using a Postgres URL in the `API_TEST_DATABASE_URL` environment variable. A Redis instance is required to queue up the test runs. You specify the Redis URL in the `API_TEST_REDIS_URL` environment variable.
 
 First you need to run the migrator against your Postgres database.
 ```shell
-docker run --env 'API_TEST_IN_URL=https://website.com/api/documentation' --env 'API_TEST_DATABASE_URL=postgres://user:password@host:port/databasename' -p '8080:80' mattpolzin2/api-test-server migrate --yes
+docker run --env 'API_TEST_IN_URL=https://website.com/api/documentation' --env 'API_TEST_DATABASE_URL=postgres://user:password@host:port/databasename' --env 'API_TEST_REDIS_URL=redis://host:port' -p '8080:80' mattpolzin2/api-test-server migrate --yes
 ```
 
 Then you can start the server.
 ```shell
-docker run --env 'API_TEST_IN_URL=https://website.com/api/documentation' --env 'API_TEST_DATABASE_URL=postgres://user:password@host:port/databasename' -p '8080:80' mattpolzin2/api-test-server
+docker run --env 'API_TEST_IN_URL=https://website.com/api/documentation' --env 'API_TEST_DATABASE_URL=postgres://user:password@host:port/databasename' --env 'API_TEST_REDIS_URL=redis://host:port' -p '8080:80' mattpolzin2/api-test-server
 ```
 
 **NOTE** We must explicitly expose the port to the host device. In this example, `http://localhost:8080` will point to the server which is listening on port `80` in the container.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ Then you can start the server.
 docker run --env 'API_TEST_IN_URL=https://website.com/api/documentation' --env 'API_TEST_DATABASE_URL=postgres://user:password@host:port/databasename' --env 'API_TEST_REDIS_URL=redis://host:port' -p '8080:80' mattpolzin2/api-test-server
 ```
 
+#### Jobs Queue
+Testing is run in a jobs queue. That queue can be run in the same process as the API server if you specify `API_TEST_IN_PROCESS_QUEUES=true` as an environment variable but the recommendation is to run the jobs service as its own process.
+
+You start the Jobs Queue using the same docker image as the serve but you specify the `queues` command.
+```shell
+docker run --env 'API_TEST_IN_URL=https://website.com/api/documentation' --env 'API_TEST_DATABASE_URL=postgres://user:password@host:port/databasename' --env 'API_TEST_REDIS_URL=redis://host:port' mattpolzin2/api-test-server queues
+```
+
 **NOTE** We must explicitly expose the port to the host device. In this example, `http://localhost:8080` will point to the server which is listening on port `80` in the container.
 
 Visit the `/docs` API endpoint to see what endpoints the server provides.

--- a/Sources/APITesting/APITestCommand.swift
+++ b/Sources/APITesting/APITestCommand.swift
@@ -95,6 +95,7 @@ public final class APITestCommand: Command {
             zipPath: zipToArg,
             testLogPath: testLogPath,
             eventLoop: eventLoop,
+            threadPool: .init(numberOfThreads: 1),
             testLogger: logger
         ).recover { _ in
             if signature.shouldFailHard {
@@ -115,15 +116,17 @@ public final class APITestCommand: Command {
         zipPath: String?,
         testLogPath: String,
         eventLoop: EventLoop,
+        threadPool: NIOThreadPool,
         testLogger: SwiftGen.Logger
     ) -> EventLoopFuture<Void> {
         return Self.kickTestsOff(
-            testProgressTracking: nil as (NullTracker, Never)?,
+            testProgressTracking: nil as (NullTracker, () -> Never)?,
             testProperties: testProperties,
             outPath: outPath,
             zipPath: zipPath,
             testLogPath: testLogPath,
             eventLoop: eventLoop,
+            threadPool: threadPool,
             requestLogger: nil,
             testLogger: testLogger
         )
@@ -140,6 +143,7 @@ public final class APITestCommand: Command {
     ///     - zipPath: (Optional) If specified, test files will be zipped and saved to a file at this path.
     ///     - testLogPath: The path and filename where plaintext test logs will be saved.
     ///     - eventLoop: The event loop on which the tests should be executed.
+    ///     - threadPool: A thread pool that can be used to perform blocking work.
     ///     - requestLogger: (Optional) If specified, a system logger to which certain process related
     ///         status updates will be logged. These updates will not be the results of tests with the
     ///         notable exception of test summaries on failure (although if this logger is `nil`,
@@ -148,12 +152,13 @@ public final class APITestCommand: Command {
     ///
     /// - returns: An `EventLoopFuture` that will have failed if any tests have failed.
     public static func kickTestsOff<Persister, Tracker: TestProgressTracker>(
-        testProgressTracking: (Tracker, Persister)?,
+        testProgressTracking: (Tracker, () -> Persister)?,
         testProperties: APITestProperties,
         outPath: String,
         zipPath: String?,
         testLogPath: String,
         eventLoop: EventLoop,
+        threadPool: NIOThreadPool,
         requestLogger: Logging.Logger?,
         testLogger: SwiftGen.Logger
     ) -> EventLoopFuture<Void> where Tracker.Persister == Persister {
@@ -163,7 +168,7 @@ public final class APITestCommand: Command {
 
         func trackProgress(_ progress: @autoclosure () -> Tracker?) -> EventLoopFuture<Void> {
             zip(progress(), testProgressTracking?.1)
-                .map { $0.0.save(on: $0.1) }
+                .map { $0.0.save(on: $0.1()) }
                 ?? eventLoop.makeSucceededFuture(())
         }
 
@@ -173,7 +178,7 @@ public final class APITestCommand: Command {
             logger: testLogger
         )
         .flatMap { trackProgress(testProgressTracker?.markBuilding()) }
-        .flatMap { openAPIDoc(on: eventLoop, from: testProperties.openAPISource) }
+        .flatMap { openAPIDoc(on: eventLoop, from: testProperties.openAPISource, threadPool: threadPool) }
         .flatMapError { error in
             let errorString: String
             if let error = error as? Abort {
@@ -189,17 +194,21 @@ public final class APITestCommand: Command {
                 on: eventLoop,
                 given: openAPIDoc,
                 to: outPath,
+                threadPool: threadPool,
                 zipToPath: zipPath,
                 testSuiteConfiguration: testProperties.testSuiteConfiguration,
+                formatGeneratedSwift: testProperties.formatGeneratedSwift,
                 logger: testLogger
             )
         }
         .flatMap { trackProgress(testProgressTracker?.markRunning()) }
-        .flatMap { runAPITestPackage(
-            on: eventLoop,
-            at: outPath,
-            testLogPath: testLogPath,
-            logger: testLogger
+        .flatMap {
+            runAPITestPackage(
+                on: eventLoop,
+                at: outPath,
+                threadPool: threadPool,
+                testLogPath: testLogPath,
+                logger: testLogger
             )
         }
         .flatMap { trackProgress(testProgressTracker?.markPassed()) }
@@ -209,14 +218,18 @@ public final class APITestCommand: Command {
         }
         .flatMapError { error in
             if let requestLogger = requestLogger {
-                requestLogger.error("Testing Failed",
-                                    metadata: ["error": .stringConvertible(String(describing: error))])
+                requestLogger.error(
+                    "Testing Failed",
+                    metadata: ["error": .stringConvertible(String(describing: error))]
+                )
                 // following is tmp to workaround above metadata not being dumped to console with previous call:
                 requestLogger.error("\(String(describing: error))")
             } else {
-                testLogger.error(path: nil,
-                                 context: "Testing Failed",
-                                 message: String(describing: error))
+                testLogger.error(
+                    path: nil,
+                    context: "Testing Failed",
+                    message: String(describing: error)
+                )
             }
 
             // once finished tracking progress, just recreate a new failed future to return.
@@ -305,7 +318,8 @@ public func prepOutputFolder(
 
 public func openAPIDoc(
     on loop: EventLoop,
-    from source: OpenAPISource
+    from source: OpenAPISource,
+    threadPool: NIOThreadPool
 ) -> EventLoopFuture<ResolvedDocument> {
     /// Get the OpenAPI documentation from a URL
     func get(_ url: URI, credentials: (username: String, password: String)? = nil) -> EventLoopFuture<ResolvedDocument> {
@@ -330,44 +344,55 @@ public func openAPIDoc(
                 return loop.makeFailedFuture(Abort(response.status))
             }
             return loop.makeSucceededFuture(response)
-        }.flatMapThrowing { response in
-            return try ClientResponse(status: response.status, headers: response.headers, body: response.body)
-                .content
-                .decode(OpenAPI.Document.self)
-                .locallyDereferenced()
-                .resolved()
+        }.flatMap { response in
+            let content = ClientResponse(
+                status: response.status,
+                headers: response.headers,
+                body: response.body
+            )
+            .content
+
+            return threadPool.runIfActive(eventLoop: loop) {
+                try content
+                    .decode(OpenAPI.Document.self)
+                    .locallyDereferenced()
+                    .resolved()
+            }
         }.always { _ in try! client.syncShutdown() }
     }
 
     switch source {
     case .file(path: let path):
-        do {
-            let filePath = URL(fileURLWithPath: path)
+        let filePath = URL(fileURLWithPath: path)
 
-            if filePath.pathExtension == "yml" || filePath.pathExtension == "yaml" {
-                let string = try String(contentsOf: filePath)
-
-                let decoder = YAMLDecoder()
-
-                return try loop.makeSucceededFuture(
-                    decoder.decode(OpenAPI.Document.self, from: string)
-                        .locallyDereferenced()
-                        .resolved()
-                )
-            } else {
-                let data = try Data(contentsOf: filePath)
-
-                let decoder = JSONDecoder.custom(dates: .iso8601)
-
-                return try loop.makeSucceededFuture(
-                    decoder.decode(OpenAPI.Document.self, from: data)
-                        .locallyDereferenced()
-                        .resolved()
-                )
+        if filePath.pathExtension == "yml" || filePath.pathExtension == "yaml" {
+            let string = threadPool.runIfActive(eventLoop: loop) {
+                try String(contentsOf: filePath)
             }
 
-        } catch let error {
-            return loop.makeFailedFuture(OpenAPISource.Error.fileReadError(error))
+            let decoder = YAMLDecoder()
+
+            return string.flatMap { string in
+                threadPool.runIfActive(eventLoop: loop) {
+                    try decoder.decode(OpenAPI.Document.self, from: string)
+                        .locallyDereferenced()
+                        .resolved()
+                }
+            }
+        } else {
+            let data = threadPool.runIfActive(eventLoop: loop) {
+                try Data(contentsOf: filePath)
+            }
+
+            let decoder = JSONDecoder.custom(dates: .iso8601)
+
+            return data.flatMap { data in
+                threadPool.runIfActive(eventLoop: loop) {
+                    try decoder.decode(OpenAPI.Document.self, from: data)
+                        .locallyDereferenced()
+                        .resolved()
+                }
+            }
         }
 
     case .basicAuth(url: let url,
@@ -385,16 +410,19 @@ public func produceAPITestPackage(
     on loop: EventLoop,
     given openAPIDoc: ResolvedDocument,
     to outputPath: String,
+    threadPool: NIOThreadPool,
     zipToPath: String? = nil,
     testSuiteConfiguration: JSONAPISwiftGen.TestSuiteConfiguration,
+    formatGeneratedSwift: Bool = true,
     logger: SwiftGen.Logger
 ) -> EventLoopFuture<Void> {
-    loop.submit {
+    threadPool.runIfActive(eventLoop: loop) {
         SwiftGen.produceAPITestPackage(
             from: openAPIDoc,
             outputTo: outputPath,
             zipToPath: zipToPath,
             testSuiteConfiguration: testSuiteConfiguration,
+            formatGeneratedSwift: formatGeneratedSwift,
             logger: logger
         )
     }
@@ -403,10 +431,11 @@ public func produceAPITestPackage(
 public func runAPITestPackage(
     on loop: EventLoop,
     at outputPath: String,
+    threadPool: NIOThreadPool,
     testLogPath: String,
     logger: SwiftGen.Logger
 ) -> EventLoopFuture<Void> {
-    loop.submit {
+    threadPool.runIfActive(eventLoop: loop) {
         try SwiftGen.runAPITestPackage(
             at: outputPath,
             testLogPath: testLogPath,

--- a/Sources/APITesting/APITestCommand.swift
+++ b/Sources/APITesting/APITestCommand.swift
@@ -414,7 +414,7 @@ public func openAPIDoc(
                 return contents
             }
 
-            let decoder = JSONDecoder.custom(dates: .iso8601)
+            let decoder = JSONDecoder()
 
             return data.flatMap { data in
                 threadPool.runIfActive(eventLoop: loop) {
@@ -425,9 +425,7 @@ public func openAPIDoc(
             }
         }
 
-    case .basicAuth(url: let url,
-                    username: let username,
-                    password: let password):
+    case .basicAuth(url: let url, username: let username, password: let password):
 
         return get(url, credentials: (username: username, password: password))
 

--- a/Sources/APITesting/APITestProperties.swift
+++ b/Sources/APITesting/APITestProperties.swift
@@ -11,10 +11,19 @@ import JSONAPISwiftGen
 public struct APITestProperties {
     let apiHostOverride: URL?
     let openAPISource: OpenAPISource
+    /// `true` by default, `false` to not
+    /// run code formatting on the Swift code
+    /// generated for the test suite.
+    let formatGeneratedSwift: Bool
 
-    public init(openAPISource: OpenAPISource, apiHostOverride: URL?) {
+    public init(
+        openAPISource: OpenAPISource,
+        apiHostOverride: URL?,
+        formatGeneratedSwift: Bool = true
+    ) {
         self.apiHostOverride = apiHostOverride
         self.openAPISource = openAPISource
+        self.formatGeneratedSwift = formatGeneratedSwift
     }
 }
 

--- a/Sources/App/Configurers/defaults.swift
+++ b/Sources/App/Configurers/defaults.swift
@@ -6,7 +6,20 @@
 //
 
 import Vapor
+import Yams
+
+extension YAMLDecoder: ContentDecoder {
+    public func decode<D>(_ decodable: D.Type, from body: ByteBuffer, headers: HTTPHeaders) throws -> D where D : Decodable {
+        return try self.decode(from: body.getString(at: body.readerIndex, length: body.readableBytes, encoding: .utf8) ?? "")
+    }
+}
 
 public func configureDefaults(for app: Application) throws {
+    // MARK: JSON
     ContentConfiguration.global.use(decoder: JSONDecoder.custom(dates: .iso8601), for: .jsonAPI)
+
+    // MARK: YAML
+    ContentConfiguration.global.use(decoder: YAMLDecoder(), for: .init(type: "application", subType: "x-yaml"))
+    ContentConfiguration.global.use(decoder: YAMLDecoder(), for: .init(type: "text", subType: "yaml"))
+    ContentConfiguration.global.use(decoder: YAMLDecoder(), for: .init(type: "text", subType: "vnd.yaml"))
 }

--- a/Sources/App/Configurers/queues.swift
+++ b/Sources/App/Configurers/queues.swift
@@ -15,5 +15,7 @@ public func addQueues(_ app: Application) throws {
     let apiTestJob = APITestJob()
     app.queues.add(apiTestJob)
 
-    try app.queues.startInProcessJobs(on: .default)
+    if Environment.inProcessJobs {
+        try app.queues.startInProcessJobs(on: .default)
+    }
 }

--- a/Sources/App/Configurers/queues.swift
+++ b/Sources/App/Configurers/queues.swift
@@ -1,0 +1,19 @@
+//
+//  queues.swift
+//  App
+//
+//  Created by Mathew Polzin on 7/4/20.
+//
+
+import Foundation
+import Vapor
+import Queues
+
+public func addQueues(_ app: Application) throws {
+    try app.queues.use(.redis(url: Environment.redisURL()))
+    
+    let apiTestJob = APITestJob()
+    app.queues.add(apiTestJob)
+
+    try app.queues.startInProcessJobs(on: .default)
+}

--- a/Sources/App/Configurers/routes.swift
+++ b/Sources/App/Configurers/routes.swift
@@ -30,6 +30,9 @@ public func addRoutes(_ app: Application, hobbled: Bool = false) throws {
 
     testController.mount(on: app, at: "api_tests")
 
+    // MARK: - Test Messages
+    APITestMessageController.mount(on: app, at: "api_test_messages")
+
     // MARK: - Watching (via WebSockets)
     let testWatchController: APITestWatchController
     if hobbled {

--- a/Sources/App/Controllers/APITestMessageController.swift
+++ b/Sources/App/Controllers/APITestMessageController.swift
@@ -15,7 +15,7 @@ import struct Logging.Logger
 import APIModels
 
 /// Controls basic CRUD operations on API Test Messages.
-final class APITestMessageController: Controller {
+public final class APITestMessageController: Controller {
     static func show(_ req: TypedRequest<ShowContext>) throws -> EventLoopFuture<Response> {
         guard let id = req.parameters.get("id", as: UUID.self) else {
             return req.response.badRequest
@@ -62,11 +62,22 @@ extension APITestMessageController {
         }
 
         let notFound: CannedResponse<API.SingleAPITestMessageDocument.ErrorDocument>
-            = Controller.jsonNotFoundError(details: "The requested tests were not found")
+            = Controller.jsonNotFoundError(details: "The requested message was not found")
 
         let badRequest: CannedResponse<API.SingleAPITestMessageDocument.ErrorDocument>
-            = Controller.jsonBadRequestError(details: "Test ID not specified in path")
+            = Controller.jsonBadRequestError(details: "Message ID not specified in path")
 
         static let shared = Self()
+    }
+}
+
+// MARK: - Route Configuration
+extension APITestMessageController {
+    public static func mount(on app: Application, at rootPath: RoutingKit.PathComponent...) {
+        app.on(
+            .GET,
+            rootPath.map(\.openAPIPathComponent) + [":id".description("Id of the API Test Message.")],
+            use: Self.show
+        )
     }
 }

--- a/Sources/App/Controllers/APITestWatchController.swift
+++ b/Sources/App/Controllers/APITestWatchController.swift
@@ -95,7 +95,7 @@ final class DatabaseAPITestWatchController: APITestWatchController {
     }
 
     private func sendNotificationsFor(test testId: API.APITestDescriptor.Id) {
-        db.logger.info("notifying \(watchers.count) watchers of test update.")
+        db.logger.debug("notifying \(watchers.count) watchers of test update.")
         let result = testController.showResults(
             id: testId.rawValue,
             shouldIncludeMessages: false,
@@ -118,7 +118,7 @@ final class DatabaseAPITestWatchController: APITestWatchController {
     }
 
     private func sendNotificationsFor(message messageId: API.APITestMessage.Id) {
-        db.logger.info("notifying \(watchers.count) watchers of message update.")
+        db.logger.debug("notifying \(watchers.count) watchers of message update.")
         let result = APITestMessageController.showResults(
             id: messageId.rawValue,
             shouldIncludeTestDescriptor: true,

--- a/Sources/App/Controllers/Controller.swift
+++ b/Sources/App/Controllers/Controller.swift
@@ -91,12 +91,14 @@ extension Controller {
         let systemLogger: Logging.Logger
         let descriptor: DB.APITestDescriptor
         let eventLoop: EventLoop
-        let database: Database
+        let database: () -> Database
 
-        init(systemLogger: Logging.Logger,
-             descriptor: DB.APITestDescriptor,
-             eventLoop: EventLoop,
-             database: Database) {
+        init(
+            systemLogger: Logging.Logger,
+            descriptor: DB.APITestDescriptor,
+            eventLoop: EventLoop,
+            database: @escaping () -> Database
+        ) {
             self.systemLogger = systemLogger
             self.descriptor = descriptor
             self.eventLoop = eventLoop
@@ -105,38 +107,55 @@ extension Controller {
 
         public func error(path: String?, context: String, message: String) {
             systemLogger.error("\(message)", metadata: ["context": .string(context)])
-            let _ = eventLoop.submit { try DB.APITestMessage(testDescriptor: self.descriptor,
-                                                          messageType: .error,
-                                                          path: path,
-                                                          context: context.isEmpty ? nil : context,
-                                                          message: message).save(on: self.database) }
+            let _ = eventLoop.submit {
+                try DB.APITestMessage(
+                    testDescriptor: self.descriptor,
+                    messageType: .error,
+                    path: path,
+                    context: context.isEmpty ? nil : context,
+                    message: message
+                ).save(on: self.database())
+            }
         }
 
         public func warning(path: String?, context: String, message: String) {
             systemLogger.warning("\(message)", metadata: ["context": .string(context)])
-            let _ = eventLoop.submit { try DB.APITestMessage(testDescriptor: self.descriptor,
-                                                          messageType: .warning,
-                                                          path: path,
-                                                          context: context.isEmpty ? nil : context,
-                                                          message: message).save(on: self.database) }
+            let _ = eventLoop.submit {
+                try DB.APITestMessage(
+                    testDescriptor: self.descriptor,
+                    messageType: .warning,
+                    path: path,
+                    context: context.isEmpty ? nil : context,
+                    message: message
+                ).save(on: self.database())
+
+            }
         }
 
         public func success(path: String?, context: String, message: String) {
             systemLogger.info("\(message)", metadata: ["context": .string(context)])
-            let _ = eventLoop.submit { try DB.APITestMessage(testDescriptor: self.descriptor,
-                                                          messageType: .success,
-                                                          path: path,
-                                                          context: context.isEmpty ? nil : context,
-                                                          message: message).save(on: self.database) }
+            let _ = eventLoop.submit {
+                try DB.APITestMessage(
+                    testDescriptor: self.descriptor,
+                    messageType: .success,
+                    path: path,
+                    context: context.isEmpty ? nil : context,
+                    message: message
+                ).save(on: self.database())
+            }
         }
 
         public func info(path: String?, context: String, message: String) {
             systemLogger.info("\(message)", metadata: ["context": .string(context)])
-            let _ = eventLoop.submit { try DB.APITestMessage(testDescriptor: self.descriptor,
-                                                             messageType: .info,
-                                                             path: path,
-                                                             context: context.isEmpty ? nil : context,
-                                                             message: message).save(on: self.database) }
+            let _ = eventLoop.submit {
+                try DB.APITestMessage(
+                    testDescriptor: self.descriptor,
+                    messageType: .info,
+                    path: path,
+                    context: context.isEmpty ? nil : context,
+                    message: message
+                ).save(on: self.database())
+            }
         }
     }
 }

--- a/Sources/App/Environment/APITestEnvironment+server.swift
+++ b/Sources/App/Environment/APITestEnvironment+server.swift
@@ -22,6 +22,13 @@ public extension Environment {
         return config
     }
 
+    enum DatabaseError: Swift.Error {
+        case invalidUrl(String)
+    }
+}
+
+// MARK: - Queues Vars
+public extension Environment {
     static func redisURL() throws -> String {
         guard let url = Environment.get("API_TEST_REDIS_URL") else {
             throw RedisError.invalidUrl("Not Set")
@@ -29,12 +36,16 @@ public extension Environment {
         return url
     }
 
-    enum DatabaseError: Swift.Error {
+    enum RedisError: Swift.Error {
         case invalidUrl(String)
     }
 
-    enum RedisError: Swift.Error {
-        case invalidUrl(String)
+    /// `true` if the Jobs Queue should be started
+    /// in the same process as the server. By default,
+    /// this is false and jobs are expected to be processed
+    /// by a queues service in its own process.
+    static var inProcessJobs: Bool {
+        return Environment.get("API_TEST_IN_PROCESS_QUEUES") == "true"
     }
 }
 

--- a/Sources/App/Environment/APITestEnvironment+server.swift
+++ b/Sources/App/Environment/APITestEnvironment+server.swift
@@ -22,7 +22,18 @@ public extension Environment {
         return config
     }
 
+    static func redisURL() throws -> String {
+        guard let url = Environment.get("API_TEST_REDIS_URL") else {
+            throw RedisError.invalidUrl("Not Set")
+        }
+        return url
+    }
+
     enum DatabaseError: Swift.Error {
+        case invalidUrl(String)
+    }
+
+    enum RedisError: Swift.Error {
         case invalidUrl(String)
     }
 }

--- a/Sources/App/Jobs/APITestJob.swift
+++ b/Sources/App/Jobs/APITestJob.swift
@@ -1,0 +1,98 @@
+//
+//  APITestJob.swift
+//  App
+//
+//  Created by Mathew Polzin on 7/4/20.
+//
+
+import Foundation
+import Vapor
+import Queues
+import APITesting
+import Fluent
+import SwiftGen
+
+struct APITestJob: Job {
+
+    struct Payload: Codable {
+        let descriptor: DB.APITestDescriptor
+        let properties: DB.APITestProperties
+        let source: DB.OpenAPISource
+
+        let outputPath: String
+    }
+
+    func dequeue(_ context: QueueContext, _ payload: Payload) -> EventLoopFuture<Void> {
+        let database = { context.application.databases
+            .database(
+                .psql,
+                logger: context.logger,
+                on: context.eventLoop
+            )!
+        }
+
+        let outPath = APITestController.outPath(for: payload.descriptor, root: payload.outputPath)
+        let testLogPath = APITestController.testLogPath(for: payload.descriptor)
+        let zipPath = APITestController.zipPath(for: payload.descriptor)
+
+        let swiftGenSource = OpenAPISource(payload.source)
+
+        let formatGeneratedSwift: Bool
+        #if swift(>=5.3)
+        formatGeneratedSwift = false
+        #else
+        formatGeneratedSwift = true
+        #endif
+
+        let testProperties = APITestProperties(
+            openAPISource: swiftGenSource,
+            apiHostOverride: payload.properties.apiHostOverride,
+            formatGeneratedSwift: formatGeneratedSwift
+        )
+
+        let testLogger = Controller.Logger(
+            systemLogger: context.logger,
+            descriptor: payload.descriptor,
+            eventLoop: context.eventLoop,
+            database: database
+        )
+
+        func descriptor(in db: Database) -> EventLoopFuture<DB.APITestDescriptor> {
+            return DB.APITestDescriptor
+                .find(payload.descriptor.id, on: db)
+                // TODO: create a new error to throw here for "test deleted from database before testing finished."
+                .unwrap(or: Abort(.notFound))
+        }
+
+        return descriptor(in: database()).flatMap { descriptor in
+            return APITestCommand.kickTestsOff(
+                testProgressTracking: (descriptor, database),
+                testProperties: testProperties,
+                outPath: outPath,
+                zipPath: zipPath,
+                testLogPath: testLogPath,
+                eventLoop: context.eventLoop,
+                threadPool: context.application.threadPool,
+                requestLogger: context.logger,
+                testLogger: testLogger
+            )
+            .flatMapError { error in
+                // if the error is actually "successfully ran tests,
+                // but the tests failed, we do not want to reschedule
+                // the job so we will map it to a successful job
+                // completion.
+                if let testFailure = error as? TestPackageSwiftError,
+                   case .testsFailed = testFailure {
+                    return context.eventLoop.makeSucceededFuture(())
+                }
+                // let errors fall through if not meeting criteria above.
+                return context.eventLoop.makeFailedFuture(error)
+            }
+        }
+    }
+
+    func error(_ context: QueueContext, _ error: Error, _ payload: Payload) -> EventLoopFuture<Void> {
+        // If you don't want to handle errors you can simply return a future. You can also omit this function entirely.
+        return context.eventLoop.future()
+    }
+}

--- a/Sources/App/Jobs/APITestJob.swift
+++ b/Sources/App/Jobs/APITestJob.swift
@@ -92,7 +92,6 @@ struct APITestJob: Job {
     }
 
     func error(_ context: QueueContext, _ error: Error, _ payload: Payload) -> EventLoopFuture<Void> {
-        // If you don't want to handle errors you can simply return a future. You can also omit this function entirely.
         return context.eventLoop.future()
     }
 }

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -2,6 +2,7 @@ import FluentPostgresDriver
 import Fluent
 import Vapor
 import APITesting
+import QueuesRedisDriver
 
 /// Called before your application initializes.
 ///
@@ -17,17 +18,14 @@ public func configure(_ app: Application, hobbled: Bool = false) throws {
 
     try configureDefaults(for: app)
 
-    // Register middleware
     addMiddleware(app)
 
     if !hobbled {
-        // Configure databases
         try addDatabases(app)
-
-        // Configure migrations
         addMigrations(app)
+
+        try addQueues(app)
     }
 
-    // Register routes
     try addRoutes(app, hobbled: hobbled)
 }

--- a/Sources/Run/main.swift
+++ b/Sources/Run/main.swift
@@ -7,7 +7,7 @@ try LoggingSystem.bootstrap(from: &environment)
 let app = Application(environment)
 defer { app.shutdown() }
 
-app.logger.info("Starting Test Server with \(System.coreCount) CPU cores available.")
+app.logger.info("\(System.coreCount) CPU cores available.")
 
 try configure(app, hobbled: false)
 

--- a/Sources/Run/main.swift
+++ b/Sources/Run/main.swift
@@ -7,6 +7,8 @@ try LoggingSystem.bootstrap(from: &environment)
 let app = Application(environment)
 defer { app.shutdown() }
 
+app.logger.info("Starting Test Server with \(System.coreCount) CPU cores available.")
+
 try configure(app, hobbled: false)
 
 try app.run()

--- a/Sources/SwiftGen/ApiTestPackageSwiftGen.swift
+++ b/Sources/SwiftGen/ApiTestPackageSwiftGen.swift
@@ -89,6 +89,8 @@ public func produceAPITestPackage(
         return decl.swiftCode
     }
 
+    let additionalLineSeparator = formatGeneratedSwift ? "" : "\n"
+
     // generate namespaces first
     let contents = try! namespaceDecls(for: routes)
         .map { try code(for: $0.enumDecl) }
@@ -108,7 +110,7 @@ public func produceAPITestPackage(
         APIRequestTestSwiftGen.testFuncDecl,
         OpenAPIExampleParseTestSwiftGen.testFuncDecl
         ].map(code)
-        .joined(separator: "")
+        .joined(separator: additionalLineSeparator)
     try! write(
         contents: testHelperContents,
         toFileAt: testDir + "/",
@@ -432,7 +434,7 @@ func writeAPIFile<T: Sequence>(
                 ? try $0.formattedSwiftCode()
                 : $0.swiftCode
         }
-        .joined(separator: "")
+        .joined(separator: formatGeneratedSwift ? "" : "\n")
 
     try write(
         contents: outputFileContents,

--- a/Sources/SwiftGen/ApiTestPackageSwiftGen.swift
+++ b/Sources/SwiftGen/ApiTestPackageSwiftGen.swift
@@ -20,30 +20,6 @@ public protocol Logger {
 typealias HttpMethod = OpenAPI.HttpMethod
 
 public func produceAPITestPackage(
-    from openAPIData: Data,
-    outputTo outPath: String,
-    zipToPath: String? = nil,
-    testSuiteConfiguration: TestSuiteConfiguration,
-    formatGeneratedSwift: Bool = true,
-    logger: Logger? = nil
-) throws {
-    let jsonDecoder = JSONDecoder()
-
-    let openAPIStructure = try jsonDecoder.decode(OpenAPI.Document.self, from: openAPIData)
-        .locallyDereferenced()
-        .resolved()
-
-    produceAPITestPackage(
-        from: openAPIStructure,
-        outputTo: outPath,
-        zipToPath: zipToPath,
-        testSuiteConfiguration: testSuiteConfiguration,
-        formatGeneratedSwift: formatGeneratedSwift,
-        logger: logger
-    )
-}
-
-public func produceAPITestPackage(
     from openAPIDocument: ResolvedDocument,
     outputTo outPath: String,
     zipToPath: String? = nil,

--- a/Tests/AppTests/APITestMessageControllerTests.swift
+++ b/Tests/AppTests/APITestMessageControllerTests.swift
@@ -1,0 +1,202 @@
+//
+//  APITestMessageControllerTests.swift
+//  AppTests
+//
+//  Created by Mathew Polzin on 7/10/20.
+//
+
+import XCTest
+import Fluent
+import XCTVapor
+import XCTFluent
+
+import App
+import APITesting
+import APIModels
+
+import JSONAPITesting
+
+final class APITestMessageControllerTests: XCTestCase {
+
+    func test_showEndpoint_malformedId_fails() throws {
+        let app = try testApp()
+        defer { app.shutdown() }
+
+        app.middleware.use(JSONAPIErrorMiddleware())
+
+        APITestMessageController.mount(on: app, at: "api_test_messages")
+
+        try app.testable().test(.GET, "api_test_messages/1234") { res in
+            XCTAssertEqual(res.status, HTTPStatus.badRequest)
+        }
+    }
+
+    func test_showEndpoint_missingResult_fails() throws {
+        let app = try testApp()
+        defer { app.shutdown() }
+
+        app.middleware.use(JSONAPIErrorMiddleware())
+
+        let testDatabase = ArrayTestDatabase()
+
+        app.databases.use(testDatabase.configuration, as: .psql)
+
+        // expect a database query to find the properties resource
+        // and respond with an empty result
+        testDatabase.append([])
+
+        APITestMessageController.mount(on: app, at: "api_test_messages")
+
+        try app.testable().test(.GET, "api_test_messages/B40806D3-B71E-4626-9878-0DE98EFC6CEC") { res in
+            XCTAssertEqual(res.status, HTTPStatus.notFound)
+        }
+    }
+
+    func test_showEndpoint_foundResult_succeeds() throws {
+        let app = try testApp()
+        defer { app.shutdown() }
+
+        app.middleware.use(JSONAPIErrorMiddleware())
+
+        let testDatabase = ArrayTestDatabase()
+
+        app.databases.use(testDatabase.configuration, as: .psql)
+
+        let properties = DB.APITestProperties(
+            openAPISourceId: UUID(),
+            apiHostOverride: nil
+        )
+
+        let descriptor = try DB.APITestDescriptor(
+            id: UUID(),
+            testProperties: properties
+        )
+
+        let testMessage = try DB.APITestMessage(
+            testDescriptor: descriptor,
+            messageType: .info,
+            path: nil,
+            context: nil,
+            message: "hello"
+        )
+
+        // expect a database query to find the message resource
+        // and respond with a resource
+        testDatabase.append([
+            TestOutput(testMessage)
+        ])
+
+        APITestMessageController.mount(on: app, at: "api_test_messages")
+
+        let expectedValue = API.APITestMessage(
+            id: .init(rawValue: testMessage.id!),
+            attributes: .init(
+                createdAt: testMessage.createdAt,
+                messageType: .info,
+                path: nil,
+                context: nil,
+                message: "hello"
+            ),
+            relationships: .init(apiTestDescriptorId: .init(rawValue: descriptor.id!)),
+            meta: .none,
+            links: .none
+        )
+
+        try app.testable().test(.GET, "api_test_messages/\(testMessage.id!.uuidString)") { res in
+            XCTAssertEqual(res.status, HTTPStatus.ok)
+
+            let body = try res.content.decode(API.SingleAPITestMessageDocument.SuccessDocument.self, using: JSONDecoder.custom(dates: .iso8601))
+
+            let bodyData = try XCTUnwrap(body.data)
+            let comparison = bodyData.primary.value.compare(to: expectedValue)
+            XCTAssert(comparison.isSame, String(describing: comparison))
+            XCTAssertEqual(body.data.includes.values, [])
+        }
+    }
+
+    func test_showEndpoint_foundResultWithIncludes_succeeds() throws {
+        let app = try testApp()
+        defer { app.shutdown() }
+
+        app.middleware.use(JSONAPIErrorMiddleware())
+
+        let testDatabase = ArrayTestDatabase()
+
+        app.databases.use(testDatabase.configuration, as: .psql)
+
+        let properties = DB.APITestProperties(
+            openAPISourceId: UUID(),
+            apiHostOverride: nil
+        )
+
+        let descriptor = try DB.APITestDescriptor(
+            id: UUID(),
+            testProperties: properties
+        )
+
+        let testMessage = try DB.APITestMessage(
+            testDescriptor: descriptor,
+            messageType: .info,
+            path: nil,
+            context: nil,
+            message: "hello"
+        )
+
+        // expect a database query to find the message resource
+        // and respond with a resource
+        // it will request the message with the descriptor with
+        // its messages to fully populate the JSON:API response.]
+        testDatabase.append(
+            [ TestOutput(testMessage) ]
+        )
+        testDatabase.append(
+            [ TestOutput(descriptor) ]
+        )
+        testDatabase.append(
+            [ TestOutput(testMessage) ]
+        )
+
+        APITestMessageController.mount(on: app, at: "api_test_messages")
+
+        let expectedPrimary = API.APITestMessage(
+            id: .init(rawValue: testMessage.id!),
+            attributes: .init(
+                createdAt: testMessage.createdAt,
+                messageType: .info,
+                path: nil,
+                context: nil,
+                message: "hello"
+            ),
+            relationships: .init(apiTestDescriptorId: .init(rawValue: descriptor.id!)),
+            meta: .none,
+            links: .none
+        )
+
+        let expectedInclude = API.APITestDescriptor(
+            id: .init(rawValue: descriptor.id!),
+            attributes: .init(
+                createdAt: descriptor.createdAt,
+                finishedAt: descriptor.finishedAt,
+                status: descriptor.status
+            ),
+            relationships: .init(
+                testPropertiesId: .init(rawValue: properties.id!),
+                messageIds: [.init(rawValue: testMessage.id!)]
+            ),
+            meta: .none,
+            links: .none
+        )
+
+        try app.testable().test(.GET, "api_test_messages/\(testMessage.id!.uuidString)?include=apiTestDescriptor") { res in
+            XCTAssertEqual(res.status, HTTPStatus.ok, "with body:\n\(res.body.string)")
+
+            let body = try res.content.decode(API.SingleAPITestMessageDocument.SuccessDocument.self, using: JSONDecoder.custom(dates: .iso8601))
+
+            let bodyData = try XCTUnwrap(body.data)
+            let comparison = bodyData.primary.value.compare(to: expectedPrimary)
+            XCTAssert(comparison.isSame, String(describing: comparison))
+            let includeComparison = bodyData.includes.values[0].a?.compare(to: expectedInclude)
+            XCTAssert(includeComparison?.isSame ?? false, String(describing: includeComparison))
+        }
+    }
+}

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -32,4 +32,42 @@ final class AppTests: XCTestCase {
             XCTAssertEqual(res.status, HTTPStatus.ok)
         }
     }
+
+    func test_routesAreMounted() throws {
+        let app = try testApp()
+        defer { app.shutdown() }
+
+        app.middleware.use(JSONAPIErrorMiddleware())
+
+        try addRoutes(app, hobbled: true)
+
+        let expectedRoutes = [
+            ["POST", "openapi_sources"],
+            ["GET", "openapi_sources"],
+            ["GET", "openapi_sources", ":id"],
+
+            ["POST", "api_test_properties"],
+            ["GET", "api_test_properties"],
+            ["GET", "api_test_properties", ":id"],
+
+            ["POST", "api_tests"],
+            ["GET", "api_tests"],
+            ["GET", "api_tests", ":id"],
+            ["GET", "api_tests", ":id", "files"],
+            ["GET", "api_tests", ":id", "logs"],
+
+            ["GET", "api_test_messages", ":id"],
+
+            ["GET", "watch"],
+
+            ["GET", "docs"]
+        ]
+
+        for path in expectedRoutes {
+            XCTAssert(app.routes.all.contains { route in [route.method.rawValue] + route.path.map(\.description) == path })
+        }
+
+        // protect against adding routes without adding them to the test
+        XCTAssertEqual(app.routes.all.count, expectedRoutes.count)
+    }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,79 @@
+version: "3.7"
+
+x-common: &common
+  environment:
+    API_TEST_IN_FILE: /app/openapi.json
+    API_TEST_ARCHIVES_PATH: /app/test_archive
+    API_TEST_DATABASE_URL: postgres://postgres:postgres@postgres:5432/postgres
+    API_TEST_REDIS_URL: redis://redis:6379
+    LOG_LEVEL: ${LOG_LEVEL:-info}
+
+volumes:
+  test_archive:
+  db_data:
+  redis_data:
+
+services:
+  api_test:
+    <<: *common
+    image: mattpolzin2/api-test-server:latest
+    command: ['serve', '--hostname', '0.0.0.0', '--port', '80']
+    build:
+      context: .
+    depends_on:
+      - postgres
+      - redis
+    ports:
+      - '8080:80'
+    volumes:
+      - test_archive:/app/test_archive
+#      - /Users/matt/Downloads/openapi_test.json:/app/openapi.json:ro
+#      - /Users/matt/Downloads/openapi_test.yml:/app/openapi.yml:ro
+
+  queues:
+    <<: *common
+    image: mattpolzin2/api-test-server:latest
+    command: ['queues']
+    depends_on:
+      - postgres
+      - redis
+    volumes:
+      - test_archive:/app/test_archive
+#      - /Users/matt/Downloads/openapi_test.json:/app/openapi.json:ro
+#      - /Users/matt/Downloads/openapi_test.yml:/app/openapi.yml:ro
+
+  postgres:
+    image: postgres:12-alpine
+    volumes:
+      - db_data:/var/lib/postgresql/data/pgdata
+    environment:
+      PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - '5434:5432'
+
+  redis:
+    image: redis:6-alpine
+    command:
+      - redis-server
+      - --appendonly
+      - 'yes'
+    volumes:
+      - redis_data:/data
+    ports:
+      - '6379:6379'
+
+  migrator:
+    <<: *common
+    image: mattpolzin2/api-test-server:latest
+    command: ['migrate', '--yes']
+    depends_on:
+      - postgres
+      - api_test
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 10


### PR DESCRIPTION
Fixes https://github.com/mattpolzin/jsonapi-openapi-test-server/issues/7.

Make concurrent test handling _much_ better.

- Handle tests as part of a jobs queue.
- Support jobs queue in-process, but recommend as its own service.
- Add docker-compose file including queues service setup.
- Don't hold onto and re-use the same Database for the duration of the long-lived testing process; instead recreate a database once per status update as if handling new requests each time.
- Put blocking tasks in test running process on packthread threads using the NIO thread pool.