### PR TITLE
Speed a functionality improvements for CLI

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -218,15 +218,6 @@
         }
       },
       {
-        "package": "swift-argument-parser",
-        "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
-        "state": {
-          "branch": null,
-          "revision": "223d62adc52d51669ae2ee19bdb8b7d9fd6fcd9c",
-          "version": "0.0.6"
-        }
-      },
-      {
         "package": "swift-backtrace",
         "repositoryURL": "https://github.com/swift-server/swift-backtrace.git",
         "state": {

--- a/Package.resolved
+++ b/Package.resolved
@@ -101,15 +101,6 @@
         }
       },
       {
-        "package": "OpenAPIReflection",
-        "repositoryURL": "https://github.com/mattpolzin/OpenAPIReflection",
-        "state": {
-          "branch": null,
-          "revision": "34eb557d0ab49a95d3a39e7a821fcb12ff50ba8a",
-          "version": "0.3.0"
-        }
-      },
-      {
         "package": "Poly",
         "repositoryURL": "https://github.com/mattpolzin/Poly",
         "state": {
@@ -215,6 +206,15 @@
           "branch": null,
           "revision": "ea9928b7f4a801b175a00b982034d9c54ecb6167",
           "version": "3.7.0"
+        }
+      },
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
+        "state": {
+          "branch": null,
+          "revision": "223d62adc52d51669ae2ee19bdb8b7d9fd6fcd9c",
+          "version": "0.0.6"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -30,13 +30,17 @@ let package = Package(
         .package(url: "https://github.com/mattpolzin/OpenAPIKit", from: "1.4.0"),
         .package(url: "https://github.com/mattpolzin/JSONAPI", from: "4.0.0"),
         .package(url: "https://github.com/jpsim/Yams", from: "3.0.0"),
-        .package(url: "https://github.com/fabianfett/pure-swift-json", .upToNextMinor(from: "0.4.0"))
+        .package(url: "https://github.com/fabianfett/pure-swift-json", .upToNextMinor(from: "0.4.0")),
+
+        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.0.6"))
     ],
     targets: [
-        /// MARK: Server App library
+        // MARK: API Models
         .target(name: "APIModels", dependencies: [
             "JSONAPI"
         ]),
+
+        // MARK: Server App Library
         .target(name: "App", dependencies: [
           .product(name: "Vapor", package: "vapor"), 
           .product(name: "Fluent", package: "fluent"),
@@ -60,9 +64,10 @@ let package = Package(
             .product(name: "JSONAPITesting", package: "JSONAPI")
         ]),
 
-        /// MARK: Terminal App library
+        // MARK: Terminal App library
         .target(name: "APITesting", dependencies: [
             .product(name: "Vapor", package: "vapor"),
+            .product(name: "ArgumentParser", package: "swift-argument-parser"),
 
             .product(name: "Yams", package: "Yams"),
             .product(name: "PureSwiftJSON", package: "pure-swift-json"),
@@ -70,14 +75,14 @@ let package = Package(
             "SwiftGen"
         ]),
 
-        /// MARK: Server API Documentation library
+        // MARK: Server API Documentation library
         .target(name: "AppAPIDocumentation", dependencies: [
             "App",
             .product(name: "JSONAPIOpenAPI", package: "JSONAPI-OpenAPI"),
             .product(name: "VaporOpenAPI", package: "VaporOpenAPI")
         ]),
 
-        /// MARK: Executables
+        // MARK: Executables
         .target(name: "Run", dependencies: ["App"]),
         .target(name: "APITest", dependencies: [
             "APITesting",
@@ -87,7 +92,7 @@ let package = Package(
             "AppAPIDocumentation"
         ]),
 
-        /// MARK: Swift Generation interface
+        // MARK: Swift Generation interface
         .target(name: "SwiftGen", dependencies: [
             .product(name: "JSONAPIOpenAPI", package: "JSONAPI-OpenAPI"),
             .product(name: "OpenAPIKit", package: "OpenAPIKit"),

--- a/Sources/APITest/main.swift
+++ b/Sources/APITest/main.swift
@@ -6,20 +6,5 @@
 //
 
 import APITesting
-import Vapor
-
-//func configure(_ app: Application) throws {
-//    // Commands
-//    app.commands.commands = [:]
-//    try app.commands.use(APITestCommand(), as: "test", isDefault: true)
-//}
-//
-//let app = Application(try .detect())
-//defer { app.shutdown() }
-//
-//try configure(app)
-//
-//try app.boot()
-//try app.run()
 
 APITestCommand.main()

--- a/Sources/APITest/main.swift
+++ b/Sources/APITest/main.swift
@@ -8,16 +8,18 @@
 import APITesting
 import Vapor
 
-func configure(_ app: Application) throws {
-    // Commands
-    app.commands.commands = [:]
-    try app.commands.use(APITestCommand(), as: "test", isDefault: true)
-}
+//func configure(_ app: Application) throws {
+//    // Commands
+//    app.commands.commands = [:]
+//    try app.commands.use(APITestCommand(), as: "test", isDefault: true)
+//}
+//
+//let app = Application(try .detect())
+//defer { app.shutdown() }
+//
+//try configure(app)
+//
+//try app.boot()
+//try app.run()
 
-let app = Application(try .detect())
-defer { app.shutdown() }
-
-try configure(app)
-
-try app.boot()
-try app.run()
+APITestCommand.main()

--- a/Sources/APITesting/APITestProperties.swift
+++ b/Sources/APITesting/APITestProperties.swift
@@ -8,7 +8,7 @@
 import Foundation
 import JSONAPISwiftGen
 
-public enum JSONDecodingStrategy {
+public enum DecodingStrategy: String, CaseIterable {
     case fast
     case stable
 }
@@ -24,18 +24,18 @@ public struct APITestProperties {
     /// which strategy should be used. This option
     /// defaults to `.stable` and is not currently used
     /// for YAML decoding.
-    let jsonDecodingStrategy: JSONDecodingStrategy
+    let decodingStrategy: DecodingStrategy
 
     public init(
         openAPISource: OpenAPISource,
         apiHostOverride: URL?,
         formatGeneratedSwift: Bool = true,
-        jsonDecodingStrategy: JSONDecodingStrategy = .stable
+        decodingStrategy: DecodingStrategy = .stable
     ) {
         self.apiHostOverride = apiHostOverride
         self.openAPISource = openAPISource
         self.formatGeneratedSwift = formatGeneratedSwift
-        self.jsonDecodingStrategy = jsonDecodingStrategy
+        self.decodingStrategy = decodingStrategy
     }
 }
 

--- a/Sources/SwiftGen/ApiTestPackageSwiftGen.swift
+++ b/Sources/SwiftGen/ApiTestPackageSwiftGen.swift
@@ -247,7 +247,7 @@ public func produceAPITestPackage(
     let totalTestCases = results.map { $0.testFunctionNames.count }.reduce(0, +)
     logger?.info(
         path: nil,
-        context: "Processing Entire OpenAPI Document",
+        context: "Processing OpenAPI Document",
         message: "Created \(totalTestCases) test cases across \(totalEndpointCount) endpoints mounted at \(totalRouteCount) routes. [Warnings: \(logger?.warningCount ?? 0), Errors: \(logger?.errorCount ?? 0)]"
     )
 }


### PR DESCRIPTION
Closes https://github.com/mattpolzin/jsonapi-openapi-test-server/issues/15.
Closes https://github.com/mattpolzin/jsonapi-openapi-test-server/issues/12.

- swap out Vapor command for ArgumentParser library.
- Also clean up and document command arguments a bit better. 
- Don't bother formatting code that is not being dumped. 
- Offer a good interface for switching between fast and stable JSON parsing. 
- Allow the user to specify the location to dump files if desired.

⚠️ Breaking Changes ⚠️ 
The `--dump-files` CLI argument used to be a flag but now it requires the location to dump files as its value. You can specify `"./out"` to get the same behavior as the flag used to trigger.